### PR TITLE
fix(prerendering): Fix caching responses again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0 (In Development)
 
+### 1.0.0-beta.2 (In Development)
+
+- Once again fix caching responses for prerendering
+
 ### 1.0.0-beta.1 (2020-05-05)
 
 - Ensure that initial response from prerendered data loaded well

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sadness",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sadness",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "useRequest hook & set of components for requesting API data within React applications",
   "scripts": {
     "build-storybook": "build-storybook -c .storybook/ -o build/",


### PR DESCRIPTION
As `getInitialResponse` called each time after `useRequest` hook called, it is needed to ensure that previously cached data will not wiped between outer component lifecycle updates.