### PR TITLE
chore: 1.0.0rc0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0 (In Development)
 
-### 1.0.0-rc.0 (In Development)
+### 1.0.0-rc.0 (2020-06-02)
 
 - Better dependency management for `useRequest` hook: load new API data on
   changing API URL (as well as on `deps` change)


### PR DESCRIPTION
- Better dependency management for `useRequest` hook: automatically reload API data on API URL change, as well as on `deps` change