### PR TITLE
ci: Provide badabump config file

### DIFF
--- a/.badabump.toml
+++ b/.badabump.toml
@@ -1,0 +1,2 @@
+[tool.badabump]
+version_type = "semver"


### PR DESCRIPTION
Tell `badabump` to use semver as version schema.

Issue: #37
Fixes: https://github.com/playpauseandstop/react-sadness/actions/runs/1088023799