### PR TITLE
ci: Fix release PR workflow again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     branches: ["master"]
 
 env:
+  BADABUMP_VERSION: "21.2.2"
   NODE_VERSION: "14.16.1"
   npm_config_user: "root"
   PYTHON_VERSION: "3.9.6"
@@ -130,3 +131,41 @@ jobs:
           npm publish --tag=${tag}
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
+
+  release:
+    needs: ["package"]
+    if: "startsWith(github.ref, 'refs/tags/')"
+    name: "Create GitHub release"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v2.3.4"
+
+      - name: "Fetch git data"
+        run: |
+          set -e
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          git fetch --prune --unshallow
+
+      - name: "Install Python"
+        uses: "actions/setup-python@v2.2.2"
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: "Install badabump"
+        run: "python3 -m pip install badabump==${{ env.BADABUMP_VERSION }}"
+
+      - id: "badabump"
+        name: "Run badabump"
+        run: 'python3 -m badabump.ci prepare_release "${{ github.ref }}"'
+
+      - name: "Create new release"
+        uses: "actions/create-release@v1.1.4"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          tag_name: "${{ steps.badabump.outputs.tag_name }}"
+          release_name: "${{ steps.badabump.outputs.release_name }}"
+          body: "${{ steps.badabump.outputs.release_body }}"
+          prerelease: "${{ steps.badabump.outputs.is_pre_release }}"

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -11,7 +11,7 @@ on:
         default: ""
 
 env:
-  BADABUMP_VERSION: "21.2.1"
+  BADABUMP_VERSION: "21.2.2"
   PYTHON_VERSION: "3.9.6"
   PYTHONUNBUFFERED: "1"
 

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -7,7 +7,7 @@ on:
     types: ["closed"]
 
 env:
-  BADABUMP_VERSION: "21.2.1"
+  BADABUMP_VERSION: "21.2.2"
   PYTHON_VERSION: "3.9.6"
   PYTHONUNBUFFERED: "1"
 


### PR DESCRIPTION
And ensure that GitHub release will be autocreated after publishing package at NPM.

Issue: #37
Fixes: https://github.com/playpauseandstop/react-sadness/actions/runs/1088037311