### PR TITLE
fix: Fix peer dependencies definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 ## Requirements
 
+- [axios](https://github.com/axios/axios) 0.21 or later
 - [React](https://reactjs.org) 16.13 or later
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "main": "lib/index.js",
   "source": "src/index.js",
   "peerDependencies": {
-    "axios": ">0.21 <1",
-    "react": ">16.13 <18",
-    "react-dom": ">16.13 < 18"
+    "axios": ">=0.21 <1",
+    "react": ">=16.13 <18",
+    "react-dom": ">=16.13 < 18"
   },
   "dependencies": {
     "immutable": "^4.0.0-rc.14",


### PR DESCRIPTION
Ensure that `react-sadness` require `axios>=0.21 <1` and `react>=16.13 <18`. In other words include lower bound versions for `axios` and `react`.